### PR TITLE
Add herokuapp domain to CSP

### DIFF
--- a/src/client/html/index.html
+++ b/src/client/html/index.html
@@ -7,7 +7,7 @@
 
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' https://*.daily.co; connect-src https://*.daily.co https://*.pluot.blue https://*.herokuapp.com localhost:* wss: ws:; worker-src 'self' blob:; style-src 'self'; font-src 'self'"
+      content="default-src 'self'; script-src 'self' https://*.daily.co; connect-src https://*.daily.co https://*.pluot.blue https://*.herokuapp.com https://*.onrender.com localhost:* wss: ws:; worker-src 'self' blob:; style-src 'self'; font-src 'self'"
     />
 
     <link rel="stylesheet" type="text/css" href="style.css" />


### PR DESCRIPTION
Heroku-deployed app fails on CSP unless we permit it in `connect-src`. This PR does that.