### PR TITLE
Cleanup and removal of unneeded op

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -40,11 +40,10 @@ import {
   Team,
 } from "../shared/types";
 import GameOrchestrator from "./orchestrator";
-import { PORT } from "./env";
+import { DAILY_API_KEY, PORT } from "./env";
 import Memory from "./store/memory";
 import GameNotFound from "../shared/errors/gameNotFound";
 import { getCookieVal, meetingTokenCookieName } from "../shared/util";
-import { DAILY_API_KEY } from "./env";
 
 // Fail early if the server is not appropriately configured.
 if (!DAILY_API_KEY) {

--- a/src/server/orchestrator.ts
+++ b/src/server/orchestrator.ts
@@ -65,19 +65,20 @@ export default class GameOrchestrator {
 
     const url = `${dailyAPIURL}/rooms/`;
     const data = JSON.stringify(req);
+
+    const roomErrMsg = "failed to create room";
+
     const res = await axios.post(url, data, { headers }).catch((error) => {
-      console.log("failed to create room:", res);
-      throw new Error(`failed to create room: ${error})`);
+      console.error(roomErrMsg, res);
+      throw new Error(`${roomErrMsg}: ${error})`);
     });
 
     if (res.status !== 200 || !res.data) {
       console.error("unexpected room creation response:", res);
-      throw new Error("failed to create room");
+      throw new Error(roomErrMsg);
     }
-    const body = JSON.parse(JSON.stringify(res.data));
-
     // Cast Daily's response to our room data interface.
-    const roomData = <ICreatedDailyRoomData>body;
+    const roomData = <ICreatedDailyRoomData>res.data;
 
     // Workaround for bug with incorrect room url return for staging.
     let roomURL = roomData.url;


### PR DESCRIPTION
This PR is a bit of cleanup and maintenance, I noticed some room for improvement when reviewing the second post.

It does the following:

* Moves an env import alongside its sibling
* Moves a room creation error message string to a const instead of hardcoding the message three times.
* Removes an unneeded JSON op.... I was converting an object... to a JSON string... back to an object... 🤷 