### PR TITLE
Allow game host to restart mid-game

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^4.17.3",
         "http-server": "^14.1.0",
         "install": "^0.13.0",
+        "jwt-decode": "^3.1.2",
         "node-cache": "^5.1.2",
         "npm": "^8.11.0",
         "redis": "^4.1.0",
@@ -24,6 +25,7 @@
       "devDependencies": {
         "@types/express": "^4.17.13",
         "@types/jest": "^27.5.0",
+        "@types/jwt-decode": "^3.1.0",
         "@types/node": "^17.0.23",
         "@typescript-eslint/eslint-plugin": "^5.22.0",
         "@typescript-eslint/parser": "^5.22.0",
@@ -3020,6 +3022,16 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/jwt-decode": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/jwt-decode/-/jwt-decode-3.1.0.tgz",
+      "integrity": "sha512-tthwik7TKkou3mVnBnvVuHnHElbjtdbM63pdBCbZTirCt3WAdM73Y79mOri7+ljsS99ZVwUFZHLMxJuJnv/z1w==",
+      "deprecated": "This is a stub types definition. jwt-decode provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "jwt-decode": "*"
+      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -7974,6 +7986,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/keyv": {
       "version": "3.1.0",
@@ -15612,6 +15629,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/jwt-decode": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/jwt-decode/-/jwt-decode-3.1.0.tgz",
+      "integrity": "sha512-tthwik7TKkou3mVnBnvVuHnHElbjtdbM63pdBCbZTirCt3WAdM73Y79mOri7+ljsS99ZVwUFZHLMxJuJnv/z1w==",
+      "dev": true,
+      "requires": {
+        "jwt-decode": "*"
+      }
+    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -19338,6 +19364,11 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true
+    },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "keyv": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@types/express": "^4.17.13",
         "@types/jest": "^27.5.0",
+        "@types/jsonwebtoken": "^8.5.8",
         "@types/jwt-decode": "^3.1.0",
         "@types/node": "^17.0.23",
         "@typescript-eslint/eslint-plugin": "^5.22.0",
@@ -41,6 +42,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "file-loader": "^6.2.0",
         "jest": "^28.0.0",
+        "jsonwebtoken": "^8.5.1",
         "nodemon": "^2.0.15",
         "parcel": "^2.4.1",
         "prettier": "^2.6.2",
@@ -3023,6 +3025,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
+      "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/jwt-decode": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/jwt-decode/-/jwt-decode-3.1.0.tgz",
@@ -4017,6 +4028,12 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -4911,6 +4928,15 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA==",
       "dev": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -7987,6 +8013,58 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "dev": true,
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=4",
+        "npm": ">=1.4.28"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dev": true,
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dev": true,
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/jwt-decode": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
@@ -8207,6 +8285,42 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -8217,6 +8331,12 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true
     },
     "node_modules/lowercase-keys": {
@@ -15629,6 +15749,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/jsonwebtoken": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
+      "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/jwt-decode": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/jwt-decode/-/jwt-decode-3.1.0.tgz",
@@ -16396,6 +16525,12 @@
         "node-int64": "^0.4.0"
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -17066,6 +17201,15 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA==",
       "dev": true
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -19365,6 +19509,53 @@
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "dev": true,
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dev": true,
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dev": true,
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "jwt-decode": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
@@ -19524,6 +19715,42 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -19534,6 +19761,12 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true
     },
     "lowercase-keys": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "express": "^4.17.3",
     "http-server": "^14.1.0",
     "install": "^0.13.0",
+    "jwt-decode": "^3.1.2",
     "node-cache": "^5.1.2",
     "npm": "^8.11.0",
     "redis": "^4.1.0",
@@ -27,6 +28,7 @@
   "devDependencies": {
     "@types/express": "^4.17.13",
     "@types/jest": "^27.5.0",
+    "@types/jwt-decode": "^3.1.0",
     "@types/node": "^17.0.23",
     "@typescript-eslint/eslint-plugin": "^5.22.0",
     "@typescript-eslint/parser": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@types/express": "^4.17.13",
     "@types/jest": "^27.5.0",
+    "@types/jsonwebtoken": "^8.5.8",
     "@types/jwt-decode": "^3.1.0",
     "@types/node": "^17.0.23",
     "@typescript-eslint/eslint-plugin": "^5.22.0",
@@ -44,6 +45,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "file-loader": "^6.2.0",
     "jest": "^28.0.0",
+    "jsonwebtoken": "^8.5.1",
     "nodemon": "^2.0.15",
     "parcel": "^2.4.1",
     "prettier": "^2.6.2",

--- a/src/client/game/game.ts
+++ b/src/client/game/game.ts
@@ -46,7 +46,7 @@ import { Team } from "../../shared/types";
 import ErrTileAlreadyExists from "./errors/errTileAlreadyExists";
 
 import joinedAudio from "../assets/audio/joined.wav";
-import { tokenIsValid } from "../../server/daily";
+import claimsAreValid from "../../shared/jwt";
 
 // Game (client-side) manages three main components of our application:
 // * The play board/space
@@ -204,9 +204,12 @@ export default class Game {
     if (token) {
       registerRestartButtonListener(() => {
         try {
-          if (!tokenIsValid(token)) return;
+          if (!claimsAreValid(token)) {
+            console.error("token doesn't appear to be valid. Is it expired?")
+            return;
+          }
         } catch (e) {
-          console.error("failed to validate meeting token:", e);
+          console.error("failed to validate meeting token claims:", e);
           return;
         }
         this.restart(token);

--- a/src/client/game/game.ts
+++ b/src/client/game/game.ts
@@ -204,8 +204,9 @@ export default class Game {
     if (token) {
       registerRestartButtonListener(() => {
         try {
-          if (!claimsAreValid(token)) {
-            console.error("token doesn't appear to be valid. Is it expired?")
+          // gameID is identical to the room name
+          if (!claimsAreValid(token, bd.gameID)) {
+            console.error("token doesn't appear to be valid. Is it expired?");
             return;
           }
         } catch (e) {

--- a/src/client/game/nav.ts
+++ b/src/client/game/nav.ts
@@ -56,8 +56,8 @@ export function registerInviteBtnListener(f: () => void) {
 }
 
 export function registerRestartButtonListener(f: () => void) {
-  const toggleMicBtn = document.getElementById("restart");
-  toggleMicBtn.onclick = () => {
+  const restartBtn = document.getElementById("restart");
+  restartBtn.onclick = () => {
     f();
   };
 }

--- a/src/client/game/nav.ts
+++ b/src/client/game/nav.ts
@@ -57,6 +57,7 @@ export function registerInviteBtnListener(f: () => void) {
 
 export function registerRestartButtonListener(f: () => void) {
   const restartBtn = document.getElementById("restart");
+  restartBtn.classList.remove("hidden");
   restartBtn.onclick = () => {
     f();
   };

--- a/src/client/game/nav.ts
+++ b/src/client/game/nav.ts
@@ -55,6 +55,13 @@ export function registerInviteBtnListener(f: () => void) {
   };
 }
 
+export function registerRestartButtonListener(f: () => void) {
+  const toggleMicBtn = document.getElementById("restart");
+  toggleMicBtn.onclick = () => {
+    f();
+  };
+}
+
 export function registerEndTurnBtnListener(team: Team, f: () => void) {
   // If this is the first time we're doing this, we may
   // need to retrieve the buttons for the first time

--- a/src/client/html/index.html
+++ b/src/client/html/index.html
@@ -112,6 +112,9 @@
             <button id="invite" aria-label="Copy invite link">
               Copy invite link
             </button>
+            <button id="restart" aria-label="Restart" class="hidden">
+              Restart
+            </button>
           </div>
         </div>
       </div>

--- a/src/server/daily.ts
+++ b/src/server/daily.ts
@@ -93,9 +93,12 @@ export async function getMeetingToken(roomName: string): Promise<string> {
   return res.data?.token;
 }
 
-export async function tokenIsValid(token: string): Promise<boolean> {
+export async function tokenIsValid(
+  token: string,
+  roomName: string
+): Promise<boolean> {
   // Check claims on the client-side first of all
-  if (!claimsAreValid(token)) return false;
+  if (!claimsAreValid(token, roomName)) return false;
 
   // Call out to Daily's meeting token REST endpoint to verify validity
   const url = `${dailyAPIURL}/meeting-tokens/${token}`;

--- a/src/server/daily.ts
+++ b/src/server/daily.ts
@@ -94,8 +94,10 @@ export async function getMeetingToken(roomName: string): Promise<string> {
 }
 
 export async function tokenIsValid(token: string): Promise<boolean> {
+  // Check claims on the client-side first of all
   if (!claimsAreValid(token)) return false;
 
+  // Call out to Daily's meeting token REST endpoint to verify validity
   const url = `${dailyAPIURL}/meeting-tokens/${token}`;
   const headers = {
     Authorization: `Bearer ${token}`,

--- a/src/server/daily.ts
+++ b/src/server/daily.ts
@@ -66,7 +66,6 @@ export async function createRoom(): Promise<CreatedDailyRoomData> {
 
 // getMeetingToken() obtains a meeting token for a room from Daily
 export async function getMeetingToken(roomName: string): Promise<string> {
-  const api = this.dailyAPIKey;
   const req = {
     properties: {
       room_name: roomName,
@@ -77,7 +76,7 @@ export async function getMeetingToken(roomName: string): Promise<string> {
 
   const data = JSON.stringify(req);
   const headers = {
-    Authorization: `Bearer ${api}`,
+    Authorization: `Bearer ${DAILY_API_KEY}`,
     "Content-Type": "application/json",
   };
 
@@ -98,18 +97,18 @@ export async function tokenIsValid(
   roomName: string
 ): Promise<boolean> {
   // Check claims on the client-side first of all
-  if (!claimsAreValid(token, roomName)) return false;
+  if (!token || !claimsAreValid(token, roomName)) return false;
 
   // Call out to Daily's meeting token REST endpoint to verify validity
   const url = `${dailyAPIURL}/meeting-tokens/${token}`;
   const headers = {
-    Authorization: `Bearer ${token}`,
+    Authorization: `Bearer ${DAILY_API_KEY}`,
     "Content-Type": "application/json",
   };
 
   const errMsg = "failed to check meeting token validity";
-  const res = await axios.post(url, { headers }).catch((error) => {
-    throw new Error(`${errMsg}: ${error})`);
+  const res = await axios.get(url, { headers }).catch((error) => {
+    throw new Error(`${errMsg}: ${error}`);
   });
   if (res.status !== 200) {
     throw new Error(`${errMsg}: got status ${res.status})`);

--- a/src/server/daily.ts
+++ b/src/server/daily.ts
@@ -1,0 +1,113 @@
+import axios from "axios";
+import claimsAreValid from "../shared/jwt";
+import { DAILY_API_KEY, DAILY_STAGING } from "./env";
+
+const isStaging = DAILY_STAGING === "true";
+
+let dailyAPIDomain = "daily.co";
+if (isStaging) {
+  dailyAPIDomain = "staging.daily.co";
+}
+
+const dailyAPIURL = `https://api.${dailyAPIDomain}/v1`;
+
+// The data we'll expect to get from Daily on room creation.
+// Daily actually returns much more data, but these are the only
+// properties we'll be using.
+interface CreatedDailyRoomData {
+  id: string;
+  name: string;
+  url: string;
+}
+
+export async function createRoom(): Promise<CreatedDailyRoomData> {
+  const apiKey = DAILY_API_KEY;
+
+  // Prepare our desired room properties. Participants will start with
+  // mics and cams off, and the room will expire in 24 hours.
+  const req = {
+    properties: {
+      exp: Math.floor(Date.now() / 1000) + 86400,
+      start_audio_off: true,
+      start_video_off: true,
+    },
+  };
+
+  // Prepare our headers, containing our Daily API key
+  const headers = {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  };
+
+  const url = `${dailyAPIURL}/rooms/`;
+  const data = JSON.stringify(req);
+
+  const roomErrMsg = "failed to create room";
+
+  const res = await axios.post(url, data, { headers }).catch((error) => {
+    console.error(roomErrMsg, res);
+    throw new Error(`${roomErrMsg}: ${error})`);
+  });
+
+  if (res.status !== 200 || !res.data) {
+    console.error("unexpected room creation response:", res);
+    throw new Error(roomErrMsg);
+  }
+  // Cast Daily's response to our room data interface.
+  const roomData = <CreatedDailyRoomData>res.data;
+
+  const roomURL = roomData.url;
+  if (isStaging && !roomURL.includes("staging.daily.co")) {
+    roomData.url = roomURL.replace("daily.co", "staging.daily.co");
+  }
+
+  return roomData;
+}
+
+// getMeetingToken() obtains a meeting token for a room from Daily
+export async function getMeetingToken(roomName: string): Promise<string> {
+  const api = this.dailyAPIKey;
+  const req = {
+    properties: {
+      room_name: roomName,
+      exp: Math.floor(Date.now() / 1000) + 86400,
+      is_owner: true,
+    },
+  };
+
+  const data = JSON.stringify(req);
+  const headers = {
+    Authorization: `Bearer ${api}`,
+    "Content-Type": "application/json",
+  };
+
+  const url = `${dailyAPIURL}/meeting-tokens/`;
+
+  const errMsg = "failed to create meeting token";
+  const res = await axios.post(url, data, { headers }).catch((error) => {
+    throw new Error(`${errMsg}: ${error})`);
+  });
+  if (res.status !== 200) {
+    throw new Error(`${errMsg}: got status ${res.status})`);
+  }
+  return res.data?.token;
+}
+
+export async function tokenIsValid(token: string): Promise<boolean> {
+  if (!claimsAreValid(token)) return false;
+
+  const url = `${dailyAPIURL}/meeting-tokens/${token}`;
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  };
+
+  const errMsg = "failed to check meeting token validity";
+  const res = await axios.post(url, { headers }).catch((error) => {
+    throw new Error(`${errMsg}: ${error})`);
+  });
+  if (res.status !== 200) {
+    throw new Error(`${errMsg}: got status ${res.status})`);
+  }
+  return true;
+}

--- a/src/server/game.ts
+++ b/src/server/game.ts
@@ -67,6 +67,8 @@ export class Game {
     this.dailyRoomURL = roomURL;
     this.wordSet = wordSet;
     this.dailyRoomName = roomName;
+    // Daily rooms are always unique per domain,
+    // so use the room name as the game ID.
     this.id = roomName;
 
     // Count how many words each team has to guess

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -183,15 +183,19 @@ function startServer() {
     });
 
     // Handle player asking to restart game
-    socket.on(restartGameEventName, async (data: RestartGameData) => {
-      await orchestrator.restartGame(
+    socket.on(restartGameEventName, (data: RestartGameData) => {
+      orchestrator.restartGame(
         socket.id,
         data.gameID,
         data.newWordSet,
         data.token
-      );
-      io.to(data.gameID).emit(gameRestartedEventName, <GameRestartedData>{
-        newWordSet: data.newWordSet,
+      ).then(() => {
+        io.to(data.gameID).emit(gameRestartedEventName, <GameRestartedData>{
+          newWordSet: data.newWordSet,
+        });
+      }).catch((e) => {
+        console.error(e);
+        socket.to(socket.id).emit(errorEventName, e);
       });
     });
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -184,6 +184,7 @@ function startServer() {
 
     // Handle player asking to restart game
     socket.on(restartGameEventName, (data: RestartGameData) => {
+      console.log(`Got restart request for game ID ${data.gameID}`);
       orchestrator
         .restartGame(socket.id, data.gameID, data.newWordSet, data.token)
         .then(() => {
@@ -192,7 +193,9 @@ function startServer() {
           });
         })
         .catch((e) => {
-          console.error(e);
+          console.error(
+            `failed to restart game ${data.gameID}: ${e.toString()}`
+          );
           socket.to(socket.id).emit(errorEventName, e);
         });
     });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -43,6 +43,7 @@ import { DAILY_API_KEY, PORT } from "./env";
 import Memory from "./store/memory";
 import GameNotFound from "../shared/errors/gameNotFound";
 import { getCookieVal, meetingTokenCookieName } from "../shared/util";
+import { getMeetingToken } from "./daily";
 
 // Fail early if the server is not appropriately configured.
 if (!DAILY_API_KEY) {
@@ -113,8 +114,7 @@ function startServer() {
     orchestrator
       .createGame(gameName, wordSet)
       .then((game) => {
-        orchestrator
-          .getMeetingToken(game.dailyRoomName)
+        getMeetingToken(game.dailyRoomName)
           .then((token) => {
             // Set meeting token for this game as a cookie
             const cookie = getCookieVal(token, game.id);
@@ -184,7 +184,12 @@ function startServer() {
 
     // Handle player asking to restart game
     socket.on(restartGameEventName, async (data: RestartGameData) => {
-      await orchestrator.restartGame(socket.id, data.gameID, data.newWordSet);
+      await orchestrator.restartGame(
+        socket.id,
+        data.gameID,
+        data.newWordSet,
+        data.token
+      );
       io.to(data.gameID).emit(gameRestartedEventName, <GameRestartedData>{
         newWordSet: data.newWordSet,
       });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -184,19 +184,17 @@ function startServer() {
 
     // Handle player asking to restart game
     socket.on(restartGameEventName, (data: RestartGameData) => {
-      orchestrator.restartGame(
-        socket.id,
-        data.gameID,
-        data.newWordSet,
-        data.token
-      ).then(() => {
-        io.to(data.gameID).emit(gameRestartedEventName, <GameRestartedData>{
-          newWordSet: data.newWordSet,
+      orchestrator
+        .restartGame(socket.id, data.gameID, data.newWordSet, data.token)
+        .then(() => {
+          io.to(data.gameID).emit(gameRestartedEventName, <GameRestartedData>{
+            newWordSet: data.newWordSet,
+          });
+        })
+        .catch((e) => {
+          console.error(e);
+          socket.to(socket.id).emit(errorEventName, e);
         });
-      }).catch((e) => {
-        console.error(e);
-        socket.to(socket.id).emit(errorEventName, e);
-      });
     });
 
     // Handle player asking to join a team

--- a/src/server/orchestrator.ts
+++ b/src/server/orchestrator.ts
@@ -97,7 +97,7 @@ export default class GameOrchestrator {
     // If someone is trying to restart while the game is still in progress,
     // verify that they are the game host (ie, have a valid Daily token)
     if (game.state === GameState.Playing) {
-      const isValid = await tokenIsValid(token);
+      const isValid = await tokenIsValid(token, game.dailyRoomName);
       if (!isValid) {
         throw new OperationForbidden();
       }

--- a/src/server/orchestrator.ts
+++ b/src/server/orchestrator.ts
@@ -95,7 +95,7 @@ export default class GameOrchestrator {
     }
 
     // If someone is trying to restart while the game is still in progress,
-    // verify that they are the game host.
+    // verify that they are the game host (ie, have a valid Daily token)
     if (game.state === GameState.Playing) {
       const isValid = await tokenIsValid(token);
       if (!isValid) {

--- a/src/server/orchestrator.ts
+++ b/src/server/orchestrator.ts
@@ -1,5 +1,3 @@
-import axios from "axios";
-import { DAILY_API_KEY, DAILY_STAGING } from "./env";
 import { Game, GameState } from "./game";
 import { Team } from "../shared/types";
 import SocketMappingNotFound from "../shared/errors/socketMappingNotFound";
@@ -8,32 +6,14 @@ import { TurnResultData } from "../shared/events";
 import { PlayerInfo, StoreClient } from "./store/store";
 import { Word } from "../shared/word";
 import Player from "../shared/player";
-
-const isStaging = DAILY_STAGING === "true";
-
-let dailyAPIDomain = "daily.co";
-if (isStaging) {
-  dailyAPIDomain = "staging.daily.co";
-}
-
-const dailyAPIURL = `https://api.${dailyAPIDomain}/v1`;
-
-// The data we'll expect to get from Daily on room creation.
-// Daily actually returns much more data, but these are the only
-// properties we'll be using.
-interface ICreatedDailyRoomData {
-  id: string;
-  name: string;
-  url: string;
-}
+import { createRoom, tokenIsValid } from "./daily";
+import OperationForbidden from "../shared/errors/operationForbidden";
 
 // GameOrchestrator serves as the entry point into
 // all game actions. It also manages storage of
 // game state in whatever cache we are using
 // (basic in-memory cache by default)
 export default class GameOrchestrator {
-  private readonly dailyAPIKey: string = DAILY_API_KEY;
-
   // storeClient() is our storage implementation, by default
   // a basic memory cache
   private readonly storeClient: StoreClient;
@@ -45,84 +25,18 @@ export default class GameOrchestrator {
   // createGame() creates a new game using the given name and word set.
   // It does so by creating a Daily room and then an instance of Game.
   async createGame(name: string, wordSet: Word[]): Promise<Game> {
-    const apiKey = DAILY_API_KEY;
-
-    // Prepare our desired room properties. Participants will start with
-    // mics and cams off, and the room will expire in 24 hours.
-    const req = {
-      properties: {
-        exp: Math.floor(Date.now() / 1000) + 86400,
-        start_audio_off: true,
-        start_video_off: true,
-      },
-    };
-
-    // Prepare our headers, containing our Daily API key
-    const headers = {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    };
-
-    const url = `${dailyAPIURL}/rooms/`;
-    const data = JSON.stringify(req);
-
-    const roomErrMsg = "failed to create room";
-
-    const res = await axios.post(url, data, { headers }).catch((error) => {
-      console.error(roomErrMsg, res);
-      throw new Error(`${roomErrMsg}: ${error})`);
-    });
-
-    if (res.status !== 200 || !res.data) {
-      console.error("unexpected room creation response:", res);
-      throw new Error(roomErrMsg);
-    }
-    // Cast Daily's response to our room data interface.
-    const roomData = <ICreatedDailyRoomData>res.data;
-
-    // Workaround for bug with incorrect room url return for staging.
-    let roomURL = roomData.url;
-
-    if (isStaging && !roomURL.includes("staging.daily.co")) {
-      roomURL = roomURL.replace("daily.co", "staging.daily.co");
-    }
+    const roomData = await createRoom();
 
     // Instantiate game with given room URL and name, and store
     // the newly created game.
-    const game = new Game(name, roomURL, roomData.name, wordSet);
+    const game = new Game(name, roomData.url, roomData.name, wordSet);
     await this.storeClient.storeGame(game);
     return game;
   }
 
-  // getMeetingToken() obtains a meeting token for a room from Daily
-  async getMeetingToken(roomName: string): Promise<string> {
-    const api = this.dailyAPIKey;
-    const req = {
-      properties: {
-        room_name: roomName,
-        exp: Math.floor(Date.now() / 1000) + 86400,
-        is_owner: true,
-      },
-    };
-
-    const data = JSON.stringify(req);
-    const headers = {
-      Authorization: `Bearer ${api}`,
-      "Content-Type": "application/json",
-    };
-
-    const url = `${dailyAPIURL}/meeting-tokens/`;
-    const res = await axios.post(url, data, { headers }).catch((error) => {
-      throw new Error(`failed to create meeting token: ${error})`);
-    });
-
-    return res.data?.token;
-  }
-
   // getGame() retrieves a game from storage
   async getGame(gameID: string): Promise<Game> {
-    const game = await this.storeClient.getGame(gameID);
-    return game;
+    return this.storeClient.getGame(gameID);
   }
 
   // joinGame adds a player to a game, if the game for their
@@ -168,11 +82,25 @@ export default class GameOrchestrator {
   }
 
   // restartGame() restarts the given game with the new word set
-  async restartGame(socketID: string, gameID: string, newWordSet: Word[]) {
+  async restartGame(
+    socketID: string,
+    gameID: string,
+    newWordSet: Word[],
+    token: string
+  ) {
     // First, find the game itself
     const game = await this.getGame(gameID);
     if (!game) {
       throw new GameNotFound(gameID);
+    }
+
+    // If someone is trying to restart while the game is still in progress,
+    // verify that they are the game host.
+    if (game.state === GameState.Playing) {
+      const isValid = await tokenIsValid(token);
+      if (!isValid) {
+        throw new OperationForbidden();
+      }
     }
 
     // Find the socket mapping associated with the user requesting this restart

--- a/src/shared/errors/noMeetingToken.ts
+++ b/src/shared/errors/noMeetingToken.ts
@@ -4,7 +4,7 @@ export default class NoMeetingToken extends Error {
   msg: string;
 
   constructor() {
-    const msg = "no meeting token founr";
+    const msg = "no meeting token found";
     super(msg);
     this.msg = msg;
 

--- a/src/shared/errors/operationForbidden.ts
+++ b/src/shared/errors/operationForbidden.ts
@@ -1,0 +1,22 @@
+export default class OperationForbidden extends Error {
+  name = "operation-forbidden";
+
+  msg: string;
+
+  constructor() {
+    const msg = "insufficient privileges to perform this operation";
+    super(msg);
+    this.msg = msg;
+
+    Object.setPrototypeOf(this, OperationForbidden.prototype);
+  }
+
+  toJSON() {
+    return {
+      error: {
+        name: this.name,
+        message: this.msg,
+      },
+    };
+  }
+}

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -74,6 +74,7 @@ export const restartGameEventName = "restart-game";
 export interface RestartGameData {
   gameID: string;
   newWordSet: Word[];
+  token: string;
 }
 
 export const gameRestartedEventName = "game-restarted";

--- a/src/shared/jwt.ts
+++ b/src/shared/jwt.ts
@@ -3,6 +3,7 @@ import jwtDecode from "jwt-decode";
 interface DailyToken {
   exp: number;
   nbf: number;
+  room_name: string;
 }
 
 // claimsAreValid checks if the claims in a JWT payload
@@ -11,16 +12,20 @@ interface DailyToken {
 // to prevent redundant API requests.
 export default function claimsAreValid(jwt: string): boolean {
   const decodedToken = jwtDecode<DailyToken>(jwt);
-  const { nbf } = decodedToken;
-  const { exp } = decodedToken;
-  if (nbf && nbf > Date.now()) {
+  const now = Date.now() / 1000;
+  const { nbf, exp, room_name } = decodedToken;
+  if (nbf && nbf > now) {
     return false;
   }
 
   // For our case, we won't allow tokens
-  // which do not expire.
-  if (!exp || exp <= Date.now()) {
+  // which do not expire, or tokens
+  // without a room name.
+  if (!exp || exp <= now || !room_name) {
     return false;
   }
-  return false;
+
+  // Token is within valid time frame and has a room name,
+  // so return the claims as valid.
+  return true;
 }

--- a/src/shared/jwt.ts
+++ b/src/shared/jwt.ts
@@ -1,0 +1,26 @@
+import jwtDecode from "jwt-decode";
+
+interface DailyToken {
+  exp: number;
+  nbf: number;
+}
+
+// claimsAreValid checks if the claims in a JWT payload
+// indicate that this token is still valid. This check
+// should be run before an online signature validation
+// to prevent redundant API requests.
+export default function claimsAreValid(jwt: string): boolean {
+  const decodedToken = jwtDecode<DailyToken>(jwt);
+  const { nbf } = decodedToken;
+  const { exp } = decodedToken;
+  if (nbf && nbf > Date.now()) {
+    return false;
+  }
+
+  // For our case, we won't allow tokens
+  // which do not expire.
+  if (!exp || exp <= Date.now()) {
+    return false;
+  }
+  return false;
+}

--- a/src/shared/jwt.ts
+++ b/src/shared/jwt.ts
@@ -3,7 +3,9 @@ import jwtDecode from "jwt-decode";
 interface DailyToken {
   exp: number;
   nbf: number;
-  room_name: string;
+  // r is going to be the claim
+  // that matches our room name
+  r: string;
 }
 
 // claimsAreValid checks if the claims in a JWT payload
@@ -26,7 +28,7 @@ export default function claimsAreValid(jwt: string, roomName: string): boolean {
 
   // We'll also require the token to contain
   // a room name, and for the room name to match.
-  if (!decodedToken.room_name || decodedToken.room_name !== roomName) {
+  if (!decodedToken.r || decodedToken.r !== roomName) {
     return false;
   }
 

--- a/src/shared/jwt.ts
+++ b/src/shared/jwt.ts
@@ -10,18 +10,23 @@ interface DailyToken {
 // indicate that this token is still valid. This check
 // should be run before an online signature validation
 // to prevent redundant API requests.
-export default function claimsAreValid(jwt: string): boolean {
+export default function claimsAreValid(jwt: string, roomName: string): boolean {
   const decodedToken = jwtDecode<DailyToken>(jwt);
   const now = Date.now() / 1000;
-  const { nbf, exp, room_name } = decodedToken;
+  const { nbf, exp } = decodedToken;
   if (nbf && nbf > now) {
     return false;
   }
 
   // For our case, we won't allow tokens
-  // which do not expire, or tokens
-  // without a room name.
-  if (!exp || exp <= now || !room_name) {
+  // which do not expire
+  if (!exp || exp <= now) {
+    return false;
+  }
+
+  // We'll also require the token to contain
+  // a room name, and for the room name to match.
+  if (!decodedToken.room_name || decodedToken.room_name !== roomName) {
     return false;
   }
 

--- a/src/shared/tests/jwt.test.ts
+++ b/src/shared/tests/jwt.test.ts
@@ -1,47 +1,57 @@
-import * as jwt from 'jsonwebtoken';
-import claimsAreValid from '../jwt';
+import * as jwt from "jsonwebtoken";
+import claimsAreValid from "../jwt";
 
 describe("jwt tests", () => {
-    test("basic valid claims", () => {
-        const now = Date.now()
-        const exp = Math.floor(now / 1000) + 86400
-        const nbf = Math.ceil(now / 1000) - 100;
+  test("basic valid claims", () => {
+    const now = Date.now();
+    const exp = Math.floor(now / 1000) + 86400;
+    const nbf = Math.ceil(now / 1000) - 100;
 
-        const payload = {
-            exp: exp,
-            nbf: nbf,
-            room_name: "my_test_room"
-        }
-        const token = jwt.sign(payload, 'test_secret');
-        const gotValid = claimsAreValid(token);
-        expect(gotValid).toBe(true);
-    });
-    test("token has expired valid claims", () => {
-        const exp = Math.floor(Date.now() / 1000) - 100;
-        const payload = {
-            exp: exp,
-            room_name: "my_test_room"
-        }
-        const token = jwt.sign(payload, 'test_secret');
-        const gotValid = claimsAreValid(token)
-        expect(gotValid).toBe(false);
-    });
-
-    test("token has no expiry claim", () => {
-        const payload = {
-            room_name: "my_test_room"
-        }
-        const token = jwt.sign(payload, 'test_secret');
-        const gotValid = claimsAreValid(token)
-        expect(gotValid).toBe(false);
-    });
-    test("token has no room claim", () => {
-        const exp = Math.floor(Date.now() / 1000) + 86400
-        const payload = {
-            exp: exp,
-        }
-        const token = jwt.sign(payload, 'test_secret');
-        const gotValid = claimsAreValid(token)
-        expect(gotValid).toBe(false);
-    });
+    const payload = {
+      exp,
+      nbf,
+      room_name: "my_test_room",
+    };
+    const token = jwt.sign(payload, "test_secret");
+    const gotValid = claimsAreValid(token, "my_test_room");
+    expect(gotValid).toBe(true);
   });
+  test("token has expired valid claims", () => {
+    const exp = Math.floor(Date.now() / 1000) - 100;
+    const payload = {
+      exp,
+      room_name: "my_test_room",
+    };
+    const token = jwt.sign(payload, "test_secret");
+    const gotValid = claimsAreValid(token, "my_test_room");
+    expect(gotValid).toBe(false);
+  });
+
+  test("token has no expiry claim", () => {
+    const payload = {
+      room_name: "my_test_room",
+    };
+    const token = jwt.sign(payload, "test_secret");
+    const gotValid = claimsAreValid(token, "my_test_room");
+    expect(gotValid).toBe(false);
+  });
+  test("token has no room claim", () => {
+    const exp = Math.floor(Date.now() / 1000) + 86400;
+    const payload = {
+      exp,
+    };
+    const token = jwt.sign(payload, "test_secret");
+    const gotValid = claimsAreValid(token, "my_test_room");
+    expect(gotValid).toBe(false);
+  });
+  test("token has invalid room claim", () => {
+    const exp = Math.floor(Date.now() / 1000) + 86400;
+    const payload = {
+      exp,
+      room_name: "my_test_room",
+    };
+    const token = jwt.sign(payload, "test_secret");
+    const gotValid = claimsAreValid(token, "my_other_room");
+    expect(gotValid).toBe(false);
+  });
+});

--- a/src/shared/tests/jwt.test.ts
+++ b/src/shared/tests/jwt.test.ts
@@ -10,7 +10,7 @@ describe("jwt tests", () => {
     const payload = {
       exp,
       nbf,
-      room_name: "my_test_room",
+      r: "my_test_room",
     };
     const token = jwt.sign(payload, "test_secret");
     const gotValid = claimsAreValid(token, "my_test_room");
@@ -20,7 +20,7 @@ describe("jwt tests", () => {
     const exp = Math.floor(Date.now() / 1000) - 100;
     const payload = {
       exp,
-      room_name: "my_test_room",
+      r: "my_test_room",
     };
     const token = jwt.sign(payload, "test_secret");
     const gotValid = claimsAreValid(token, "my_test_room");
@@ -29,7 +29,7 @@ describe("jwt tests", () => {
 
   test("token has no expiry claim", () => {
     const payload = {
-      room_name: "my_test_room",
+      r: "my_test_room",
     };
     const token = jwt.sign(payload, "test_secret");
     const gotValid = claimsAreValid(token, "my_test_room");
@@ -48,7 +48,7 @@ describe("jwt tests", () => {
     const exp = Math.floor(Date.now() / 1000) + 86400;
     const payload = {
       exp,
-      room_name: "my_test_room",
+      r: "my_test_room",
     };
     const token = jwt.sign(payload, "test_secret");
     const gotValid = claimsAreValid(token, "my_other_room");

--- a/src/shared/tests/jwt.test.ts
+++ b/src/shared/tests/jwt.test.ts
@@ -1,0 +1,47 @@
+import * as jwt from 'jsonwebtoken';
+import claimsAreValid from '../jwt';
+
+describe("jwt tests", () => {
+    test("basic valid claims", () => {
+        const now = Date.now()
+        const exp = Math.floor(now / 1000) + 86400
+        const nbf = Math.ceil(now / 1000) - 100;
+
+        const payload = {
+            exp: exp,
+            nbf: nbf,
+            room_name: "my_test_room"
+        }
+        const token = jwt.sign(payload, 'test_secret');
+        const gotValid = claimsAreValid(token);
+        expect(gotValid).toBe(true);
+    });
+    test("token has expired valid claims", () => {
+        const exp = Math.floor(Date.now() / 1000) - 100;
+        const payload = {
+            exp: exp,
+            room_name: "my_test_room"
+        }
+        const token = jwt.sign(payload, 'test_secret');
+        const gotValid = claimsAreValid(token)
+        expect(gotValid).toBe(false);
+    });
+
+    test("token has no expiry claim", () => {
+        const payload = {
+            room_name: "my_test_room"
+        }
+        const token = jwt.sign(payload, 'test_secret');
+        const gotValid = claimsAreValid(token)
+        expect(gotValid).toBe(false);
+    });
+    test("token has no room claim", () => {
+        const exp = Math.floor(Date.now() / 1000) + 86400
+        const payload = {
+            exp: exp,
+        }
+        const token = jwt.sign(payload, 'test_secret');
+        const gotValid = claimsAreValid(token)
+        expect(gotValid).toBe(false);
+    });
+  });


### PR DESCRIPTION
This PR introduces utilization of our Daily meeting tokens in a basic feature: restarting the game mid-play.

* The user who created the game is considered a game host. We already retrieve an owner token for them and store it in a cookie on the client side.
* Up until now, this token was unused. Now, the idea is to show how a meeting token can be validated and used for a simple game feature: the game host should be able to restart the game mid-play.
* A shared module is introduced which is used on the client and server side to first validate basic claims: including enforcing the existence of an `exp` and `r` claim. For the purpose of this demo, we will not allow tokens which do not contain these.
* If the client confirms that the user has what _appears_ to be a valid token, a "Restart" button is shown in their game controls. When they click it, the server uses Daily's meeting token validation endpoint to verify that the token is indeed valid. If so, the game is restarted.