### PR TITLE
use `userMediaConstraints` instead of `setBandwidth()`; fix eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "webpack",
     "start": "node dist/server/index.js",
-    "test": "jest"
+    "test": "jest",
+    "fix": "eslint src/ --fix"
   },
   "keywords": [],
   "author": "",

--- a/src/client/daily.ts
+++ b/src/client/daily.ts
@@ -35,15 +35,13 @@ export class Call {
       dailyConfig: {
         experimentalChromeVideoMuteLightOff: true,
         camSimulcastEncodings: [{ maxBitrate: 600000, maxFramerate: 30 }],
+        // Our tiles will always be 100px x 100px, so set the track
+        // constraints to match
+        userMediaVideoConstraints: {
+          width: videoTileSize,
+          height: videoTileSize,
+        },
         avoidEval: true,
-      },
-    });
-    // Our tiles will always be 100px x 100px, so set the bandwidth
-    // to match
-    this.callObject.setBandwidth({
-      trackConstraints: {
-        width: videoTileSize,
-        height: videoTileSize,
       },
     });
   }

--- a/src/server/tests/game.test.ts
+++ b/src/server/tests/game.test.ts
@@ -48,7 +48,8 @@ describe("Spymaster tests", () => {
       }
     }
     expect(player.isSpymaster).toBe(true);
-    const spymasters = game["spymasters"]
+    // eslint-disable-next-line prefer-destructuring,@typescript-eslint/dot-notation
+    const spymasters = game["spymasters"];
     expect(spymasters.team2).toBe(pid);
     expect(spymasters.team1).toBeFalsy();
   });
@@ -60,11 +61,13 @@ describe("Spymaster tests", () => {
 
     game.setSpymaster(pid, Team.Team1);
 
-    let spymasters = game["spymasters"]
+    // eslint-disable-next-line prefer-destructuring,@typescript-eslint/dot-notation
+    let spymasters = game["spymasters"];
     expect(spymasters.team1).toBe(pid);
     expect(spymasters.team2).toBeFalsy();
 
     game.setSpymaster(pid, Team.Team2);
+    // eslint-disable-next-line @typescript-eslint/dot-notation
     spymasters = game["spymasters"];
     expect(spymasters.team2).toBe(pid);
     expect(spymasters.team1).toBeFalsy();
@@ -76,9 +79,12 @@ describe("Spymaster tests", () => {
     game.addPlayer(pid, Team.Team1);
     game.setSpymaster(pid, Team.Team1);
 
-    expect(game["spymasters"].team1).toBe(pid);
+    // eslint-disable-next-line prefer-destructuring,@typescript-eslint/dot-notation
+    const spymasters = game["spymasters"];
+
+    expect(spymasters.team1).toBe(pid);
     game.removePlayer(pid);
-    expect(game["spymasters"].team2).toBeNull();
+    expect(spymasters.team2).toBeNull();
   });
 });
 


### PR DESCRIPTION
This PR:

* Replaces our single use of `setBandwidth()` to set our tile size constraints with a `userMediaConstraints` config option instead. This was introduced a while ago and presently, the two options to set these constraints seem to be either waiting until the `"joined-meeting"` event fires and _then_ calling `setBandwidth()` or using this one configuration parameter when creating the call object. Because in this case the constraints only need to be set once, this PR goes for the single config parameter.
* Marks as ignored some eslint errors that eslint tries to auto-fix. The tool's suggested fixes actually result in a compile error, so this PR explicitly prevents this from happening. 