### PR TITLE
Only return audio track if participant is not local.

### DIFF
--- a/src/client/daily.ts
+++ b/src/client/daily.ts
@@ -137,15 +137,18 @@ export class Call {
     if (!tracks) return mediaTracks;
 
     const vt = tracks.video;
-    const at = tracks.audio;
-
     const vs = vt?.state;
     if (vt.persistentTrack && (vs === playableState || vs === loadingState)) {
       mediaTracks.videoTrack = vt.persistentTrack;
     }
-    const as = at?.state;
-    if (at.persistentTrack && (as === playableState || as === loadingState)) {
-      mediaTracks.audioTrack = at.persistentTrack;
+
+    // Only get audio track if this is a remote participant
+    if (!p.local) {
+      const at = tracks.audio;
+      const as = at?.state;
+      if (at.persistentTrack && (as === playableState || as === loadingState)) {
+        mediaTracks.audioTrack = at.persistentTrack;
+      }
     }
     return mediaTracks;
   }


### PR DESCRIPTION
This PR only sets the audio track for a Daily participant if that participant is not local. There is no need to return an audio track for a local participant.