### PR TITLE
Really _really_ destroy WebMediaPlayer on participant departure

### DIFF
--- a/src/client/game/board.ts
+++ b/src/client/game/board.ts
@@ -508,7 +508,19 @@ export class Board {
 // removeTile() removes a play tile, if any.
 export function removeTile(playerID: string) {
   const ele = document.getElementById(getParticipantTileID(playerID));
-  ele?.remove();
+  if (!ele) return;
+  // Get video tag from player's tile.
+  const videoTags = ele.getElementsByTagName("video");
+
+  // Set all src objects to null to prevent detached streams
+  // There should only ever be ONE element per participant div,
+  // but iterate over all just in case.
+  for (let i = 0; i < videoTags.length; i += 1) {
+    const vt = videoTags[i];
+    vt.srcObject = null;
+  }
+
+  ele.remove();
 }
 
 // getParticipantTileID() returns an ID for the participant

--- a/src/client/game/board.ts
+++ b/src/client/game/board.ts
@@ -509,7 +509,7 @@ export class Board {
 export function removeTile(playerID: string) {
   const ele = document.getElementById(getParticipantTileID(playerID));
   if (!ele) return;
-  // Get video tag from player's tile.
+  
   const videoTags = ele.getElementsByTagName("video");
 
   // Set all src objects to null to prevent detached streams


### PR DESCRIPTION
This PR explicitly sets the `srcObject` of any `HTMLVideoElement`s of a departed participant to `null`. Just removing the video element from the DOM pauses `WebMediaPlayer` instead of destroying it. 

Pre change (note final `kPause` event):
<img width="569" alt="image" src="https://user-images.githubusercontent.com/65890040/193037018-c8e7b757-f5ad-4c58-8b7d-03d1842a312e.png">

Post change (note final `kWebMediaPlayerDestroyed` event):
<img width="569" alt="image" src="https://user-images.githubusercontent.com/65890040/193036509-81a299e8-a8c7-48f1-9772-58a66eb1ef27.png">