### PR TITLE
Remove autoplay in favor of play() + handling "NotAllowedError"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@daily-co/daily-js": "^0.27.0",
+        "@daily-co/daily-js": "^0.31.0",
         "@redis/client": "^1.1.0",
         "axios": "^0.26.1",
         "cookie-parser": "^1.4.6",
@@ -675,9 +675,9 @@
       }
     },
     "node_modules/@daily-co/daily-js": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.27.0.tgz",
-      "integrity": "sha512-4k7xTx1+1KzwbLyqFl5Cky25mCaKzVzfRs75fgw+HLRgJgjqh9Vi6GGsSDopy3lQFps7rXweHgRWlT5DN8DMQw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.31.0.tgz",
+      "integrity": "sha512-kx4HNtrEDU+0vOlZLpmqc4SfecGi/yA8iZEf/8YRublPBqEpV0mfR8I/kirfn1MBFDqM28eacsqzEs22CN2xbQ==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "bowser": "^2.8.1",
@@ -14171,9 +14171,9 @@
       }
     },
     "@daily-co/daily-js": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.27.0.tgz",
-      "integrity": "sha512-4k7xTx1+1KzwbLyqFl5Cky25mCaKzVzfRs75fgw+HLRgJgjqh9Vi6GGsSDopy3lQFps7rXweHgRWlT5DN8DMQw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.31.0.tgz",
+      "integrity": "sha512-kx4HNtrEDU+0vOlZLpmqc4SfecGi/yA8iZEf/8YRublPBqEpV0mfR8I/kirfn1MBFDqM28eacsqzEs22CN2xbQ==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "bowser": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@daily-co/daily-js": "^0.27.0",
+    "@daily-co/daily-js": "^0.31.0",
     "@redis/client": "^1.1.0",
     "axios": "^0.26.1",
     "cookie-parser": "^1.4.6",

--- a/src/client/daily.ts
+++ b/src/client/daily.ts
@@ -1,6 +1,5 @@
 import DailyIframe, {
   DailyCall,
-  DailyEventObjectParticipant,
   DailyParticipant,
   DailyEventObjectTrack,
 } from "@daily-co/daily-js";
@@ -9,7 +8,7 @@ import { videoTileSize } from "./config";
 // Define handler types that the game class will use to specify
 // custom behavior based on call events
 export type JoinHandler = (e: DailyParticipant) => void;
-export type LeaveHandler = (e: DailyEventObjectParticipant) => void;
+export type LeaveHandler = (e: DailyParticipant) => void;
 export type TrackStartedHandler = (e: DailyEventObjectTrack) => void;
 export type TrackStoppedHandler = (e: DailyEventObjectTrack) => void;
 export type ParticipantUpdatedHandler = (e: DailyParticipant) => void;
@@ -108,7 +107,7 @@ export class Call {
   registerParticipantLeftHandler(h: LeaveHandler) {
     this.callObject.on("participant-left", (e) => {
       if (!e) return;
-      h(e);
+      h(e.participant);
     });
   }
 

--- a/src/client/game/board.ts
+++ b/src/client/game/board.ts
@@ -509,7 +509,7 @@ export class Board {
 export function removeTile(playerID: string) {
   const ele = document.getElementById(getParticipantTileID(playerID));
   if (!ele) return;
-  
+
   const videoTags = ele.getElementsByTagName("video");
 
   // Set all src objects to null to prevent detached streams

--- a/src/client/game/board.ts
+++ b/src/client/game/board.ts
@@ -566,7 +566,6 @@ export function updateMedia(participantID: string, newTracks: Tracks) {
     if (newAudio) tracks.push(newAudio);
     const newStream = new MediaStream(tracks);
     video.srcObject = newStream;
-    video.id = participantID;
     playMedia(video);
     return;
   }

--- a/src/client/game/board.ts
+++ b/src/client/game/board.ts
@@ -24,6 +24,7 @@ import { flyEmojis, Mood } from "../util/effects";
 import ErrNoTeamDOM from "./errors/errNoTeamDOM";
 import showGameError from "./errors/error";
 import ErrGeneric from "./errors/errGeneric";
+import ErrMediaAutoplay from "./errors/errMediaPlay";
 
 export interface BoardData {
   roomURL: string;
@@ -465,7 +466,6 @@ export class Board {
     participantTile.className = "tile";
 
     const video = document.createElement("video");
-    video.autoplay = true;
     if (p.local) {
       video.muted = true;
     }
@@ -566,45 +566,77 @@ export function updateMedia(participantID: string, newTracks: Tracks) {
     if (newAudio) tracks.push(newAudio);
     const newStream = new MediaStream(tracks);
     video.srcObject = newStream;
+    video.id = participantID;
+    playMedia(video);
     return;
   }
 
-  refreshAudioTrack(existingStream, newAudio);
+  // This boolean will define whether we play the video element again
+  // This should be `true` if any of the tracks have changed.
+  let needsPlay = false;
+  needsPlay = refreshAudioTrack(existingStream, newAudio);
 
   // We have an extra if check here compared to the audio track
   // handling above, because the video track also dictates
   // whether we should hide the video DOM element.
   if (newVideo) {
-    refreshVideoTrack(existingStream, newVideo);
+    if (refreshVideoTrack(existingStream, newVideo) && !needsPlay) {
+      needsPlay = true;
+    }
+
     video.classList.remove("hidden");
   } else {
     // If there's no video to be played, hide the element.
     video.classList.add("hidden");
   }
+  if (needsPlay) {
+    playMedia(video);
+  }
+}
+
+// playMedia() tries to call play() on the video
+// element if it is not already playing.
+function playMedia(video: HTMLVideoElement) {
+  const isPlaying =
+    !video.paused &&
+    !video.ended &&
+    video.currentTime > 0 &&
+    video.readyState > video.HAVE_CURRENT_DATA;
+
+  if (isPlaying) return;
+
+  video.play().catch((e) => {
+    if (e instanceof Error && e.name === "NotAllowedError") {
+      showGameError(new ErrMediaAutoplay());
+      return;
+    }
+
+    console.warn("Failed to play media.", e);
+  });
 }
 
 // refreshAudioTrack() refreshes a participant's audio track in the DOM.
 function refreshAudioTrack(
   existingStream: MediaStream,
   newAudioTrack: MediaStreamTrack | null
-) {
+): boolean {
   // If there is no new track, just early out
   // and keep the old track on the stream as-is.
-  if (!newAudioTrack) return;
+  if (!newAudioTrack) return false;
   const existingTracks = existingStream.getAudioTracks();
-  refreshTrack(existingStream, existingTracks, newAudioTrack);
+  return refreshTrack(existingStream, existingTracks, newAudioTrack);
 }
 
 // refreshVideoTrack() refreshes a participant's video track in the DOM.
 function refreshVideoTrack(
   existingStream: MediaStream,
   newVideoTrack: MediaStreamTrack | null
-) {
+): boolean {
   // If there is no new track, just early out
   // and keep the old track on the stream as-is.
-  if (!newVideoTrack) return;
+  if (!newVideoTrack) return false;
   const existingTracks = existingStream.getVideoTracks();
-  refreshTrack(existingStream, existingTracks, newVideoTrack);
+  return refreshTrack(existingStream, existingTracks, newVideoTrack);
 }
 
 // refreshTrack() compares the old tracks in a stream with new tracks
@@ -613,13 +645,13 @@ function refreshTrack(
   existingStream: MediaStream,
   oldTracks: MediaStreamTrack[],
   newTrack: MediaStreamTrack
-) {
+): boolean {
   const trackCount = oldTracks.length;
   // If there is no matching old track,
   // just add the new track.
   if (trackCount === 0) {
     existingStream.addTrack(newTrack);
-    return;
+    return true;
   }
   if (trackCount > 1) {
     console.warn(
@@ -632,5 +664,7 @@ function refreshTrack(
   if (oldTrack.id !== newTrack.id) {
     existingStream.removeTrack(oldTrack);
     existingStream.addTrack(newTrack);
+    return true;
   }
+  return false;
 }

--- a/src/client/game/errors/errMediaPlay.ts
+++ b/src/client/game/errors/errMediaPlay.ts
@@ -1,0 +1,52 @@
+import { GameError } from "./error";
+
+const msg = "It's okay. Click here to (hopefully) fix it!";
+export default class ErrMediaAutoplay extends Error implements GameError {
+  name = "media-autoplay-blocked";
+
+  unrecoverable: boolean = false;
+
+  constructor() {
+    super(msg);
+
+    Object.setPrototypeOf(this, ErrMediaAutoplay.prototype);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  getButton(additionalOnClick: () => void): HTMLButtonElement {
+    // Create Button element
+    const button = document.createElement("button");
+    button.innerText = "Play!";
+
+    // Set up onclick handler
+    button.onclick = () => {
+      // Try to replay all participant media elements
+      const t1 = document.getElementById("team1");
+      const t2 = document.getElementById("team2");
+      const ob = document.getElementById("observers");
+      if (t1) playVideoTags(t1);
+      if (t2) playVideoTags(t2);
+      if (ob) playVideoTags(ob);
+
+      additionalOnClick();
+    };
+    return button;
+  }
+
+  toJSON() {
+    return {
+      error: {
+        name: this.name,
+        message: msg,
+      },
+    };
+  }
+}
+
+function playVideoTags(parent: HTMLElement) {
+  const videos = parent.getElementsByTagName("video");
+  for (let i = 0; i < videos.length; i += 1) {
+    const v = videos[i];
+    v.play();
+  }
+}

--- a/src/client/game/errors/errMediaPlay.ts
+++ b/src/client/game/errors/errMediaPlay.ts
@@ -13,7 +13,9 @@ export default class ErrMediaAutoplay extends Error implements GameError {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  getButton(additionalOnClick: () => void): HTMLButtonElement {
+  getButton(
+    additionalOnClick: (btn: HTMLButtonElement) => void
+  ): HTMLButtonElement {
     // Create Button element
     const button = document.createElement("button");
     button.innerText = "Play!";
@@ -28,7 +30,7 @@ export default class ErrMediaAutoplay extends Error implements GameError {
       if (t2) playVideoTags(t2);
       if (ob) playVideoTags(ob);
 
-      additionalOnClick();
+      additionalOnClick(button);
     };
     return button;
   }

--- a/src/client/game/errors/error.ts
+++ b/src/client/game/errors/error.ts
@@ -10,7 +10,7 @@ const oopsMessages = [
 
 export interface GameError extends Error {
   unrecoverable: boolean;
-  getButton?: (onclick: () => void) => HTMLButtonElement;
+  getButton?: (onclick: (btn: HTMLButtonElement) => void) => HTMLButtonElement;
 }
 
 export default function showGameError(error: GameError) {
@@ -50,9 +50,9 @@ export default function showGameError(error: GameError) {
     defaultButton.classList.add("invisible");
 
     // define additional onClick cleanup
-    const oc = () => {
+    const oc = (button: HTMLButtonElement) => {
       onClickShared();
-      container.removeChild(defaultButton);
+      container.removeChild(button);
     };
     const button = error.getButton(oc);
     container.appendChild(button);

--- a/src/client/game/game.ts
+++ b/src/client/game/game.ts
@@ -190,7 +190,7 @@ export default class Game {
     });
 
     this.call.registerParticipantLeftHandler((p) => {
-      this.board?.eject(p.participant.session_id);
+      this.board?.eject(p.session_id);
     });
 
     this.call.registerParticipantUpdatedHandler((p) => {


### PR DESCRIPTION
Sorry about the length of this description, feel free to just read the code and come back to this if you wonder "But why?"

# "But why?"

## Because Safari

Today when testing out some audio issues in another demo, @jamsea and I tried hopping into CoD. We noticed that media tracks are not auto played _despite active gestures on the screen being made_ in Safari, until the user turned on their own camera or microphone. In the screenshot below the "chrome" user is actually unmuted (both camera and mic). "You" (the safari user) do not see that chrome user until you unmute one of your own devices.

<img width="355" alt="image" src="https://user-images.githubusercontent.com/65890040/193117647-e52cc881-eef3-4c0f-a2c3-f9f4a7c2ee32.png">

You should be able to easily repro this by going to the deployed version of CoD, _at least_ on Mac OS Monterey 12.6 (prepare for a slow initial loading time due to some render.com throttling): http://code-of-daily-modern-wordfare.onrender.com :

1. Open the above in Chrome. Turn on video _and audio_
1. Click the invite link in the controls down below and paste the URL in Safari
1. Note that the Chrome participant's media is not played. 
1. Turn on your own camera
1. Note that both participants' media is now played

### `NotAllowedError` and autoplay

This seems to be an autoplay permission error, in that despite the user making "gestures" on the page, the unmuted video is still not allowed to play. This plays fine in Chrome and FF (in my testing), but Safari is Safari.

### Remediation 1: scrap autoplay

So in this PR I am trying to scrap autoplay and call `play()` on the video tag in the following cases:

* A new `MediaStream` is added as a video `srcObject`
* Tracks on an existing `MediaStream` are replaced

### Remediation 2: an added flow to handle `NotAllowedError`

Originally, I was getting the same permission error in Safari even with the above technique change. The above was added just so that we could catch the error and respond. To that end, the PR adds a new error: `ErrMediaAutoplay`, which is shown when this particular permission error is hit. It encourages the user to hit a given "Play" button manually, which Safari seems to be happy with as a user gesture to begin playing. The error then gathers up all participant video elements in existence in the DOM and calls `play()` on them (a brute-force attempt to play _all the things_)

### BUT WAIT, THERE'S MORE

The above worked well in my testing, until my entire machine froze up and I had to reboot, which also included a Safari update. _AT THIS POINT_, just the technique change of removing `autoplay` and calling `play()` instead (as described in "Remediation 1" above) seems to avoid the permission error. So the error message described is no longer consistently triggered for me. 

_But_ considering we've seen so much wonkiness with Safari at this point, I propose leaving this in, in case another Safari version or some other configuration _does_ still trigger the permissions error. This way, whoever runs into this has a way to (hopefully) fix it and keep playing. 

--------

(Aside: if this does end up being the correct approach we probably want to say something about this in our upcoming track handling post...)

-------

(Aside 2: This PR **does not address** the following video issue I posted about earlier, also seemingly triggered by Safari)

![image](https://user-images.githubusercontent.com/65890040/193120842-aef87b94-4bde-4e37-a8d2-b379d9472a62.png)
